### PR TITLE
🐱‍💻 Add cooperation with game's multithreading to slow ccts

### DIFF
--- a/src/autocct.ts
+++ b/src/autocct.ts
@@ -19,6 +19,8 @@ export async function main(ns: NS) {
 		depth
 	)
 
+	const cooperative = async () => await ns.sleep(20 /* ms */)
+
 	scannerService.scan()
 
 	let successes = 0
@@ -33,9 +35,10 @@ export async function main(ns: NS) {
 			for (const cctFile of cctFiles) {
 				const type = ns.codingcontract.getContractType(cctFile, server.name)
 				const data = ns.codingcontract.getData(cctFile, server.name)
-				const { known, attempt, result } = evaluateCct(
+				const { known, attempt, result } = await evaluateCct(
 					type,
 					data,
+					cooperative,
 					logger.getLogger(),
 					force
 				)

--- a/src/cct/index.ts
+++ b/src/cct/index.ts
@@ -31,12 +31,13 @@ export interface CctEvaluation {
 	result: any
 }
 
-export function evaluateCct(
+export async function evaluateCct(
 	type: string,
 	data: any,
+	cooperative: () => Promise<any> = () => Promise.resolve(),
 	logger?: Logger<any>,
 	allResults = false
-): CctEvaluation {
+): Promise<CctEvaluation> {
 	switch (type) {
 		case 'Algorithmic Stock Trader I':
 			return {
@@ -99,14 +100,10 @@ export function evaluateCct(
 				result: enc2(data),
 			}
 		case 'Find All Valid Math Expressions':
-			const quickVmeAttempt = data.length <= 10
 			return {
 				known: true,
-				attempt: quickVmeAttempt,
-				result:
-					quickVmeAttempt || allResults
-						? solveValidMathExpressions(data)
-						: undefined,
+				attempt: true,
+				result: solveValidMathExpressions(data, cooperative),
 			}
 		case 'Find Largest Prime Factor':
 			return {
@@ -169,17 +166,16 @@ export function evaluateCct(
 				result: subarrayMaximumSum(data, logger),
 			}
 		case 'Total Ways to Sum':
-			const quickSumAttempt = data < 50
 			return {
 				known: true,
-				attempt: quickSumAttempt,
-				result: quickSumAttempt || allResults ? sumPartitions(data) : undefined,
+				attempt: true,
+				result: await sumPartitions(data, cooperative),
 			}
 		case 'Total Ways to Sum II':
 			return {
 				known: true,
 				attempt: true,
-				result: sumCombinations(data),
+				result: await sumCombinations(data, cooperative),
 			}
 		case 'Unique Paths in a Grid I':
 			return {

--- a/src/cct/total-ways-to-sum1.test.ts
+++ b/src/cct/total-ways-to-sum1.test.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai'
 import { sumPartitions } from './total-ways-to-sum1'
 
 describe('Total Ways to Sum', () => {
-	const solveExample = (example: number, expected: number) => () => {
-		const result = sumPartitions(example)
+	const solveExample = (example: number, expected: number) => async () => {
+		const result = await sumPartitions(example, () => Promise.resolve())
 		expect(result).to.equal(expected)
 	}
 

--- a/src/cct/total-ways-to-sum1.ts
+++ b/src/cct/total-ways-to-sum1.ts
@@ -13,18 +13,26 @@ It is possible write four as a sum in exactly four different ways:
 How many different distinct ways can the number 17 be written as a sum of at least two positive integers?
 */
 
-function* partition(n: number, I = 1): Iterable<number[]> {
+async function* partition(
+	n: number,
+	cooperative: () => Promise<any>,
+	I = 1
+): AsyncIterable<number[]> {
 	yield [n]
 	for (let i = I; i < Math.floor(n / 2) + 1; i++) {
-		for (const p of partition(n - i, i)) {
+		for await (const p of partition(n - i, cooperative, i)) {
 			yield [i, ...p]
 		}
+		await cooperative()
 	}
 }
 
-export function sumPartitions(input: number) {
+export async function sumPartitions(
+	input: number,
+	cooperative: () => Promise<any>
+) {
 	let count = 0
-	for (const p of partition(input)) {
+	for await (const p of partition(input, cooperative)) {
 		if (p.length > 1) {
 			count++
 		}

--- a/src/cct/total-ways-to-sum2.test.ts
+++ b/src/cct/total-ways-to-sum2.test.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai'
 import { sumCombinations, SumInput } from './total-ways-to-sum2'
 
 describe('Total Ways to Sum II', () => {
-	const solveExample = (data: SumInput, expected: number) => () => {
-		const result = sumCombinations(data)
+	const solveExample = (data: SumInput, expected: number) => async () => {
+		const result = await sumCombinations(data, () => Promise.resolve())
 		expect(result).to.equal(expected)
 	}
 

--- a/src/cct/total-ways-to-sum2.ts
+++ b/src/cct/total-ways-to-sum2.ts
@@ -12,13 +12,14 @@ You may use each integer in the set zero or more times.
 
 export type SumInput = [number, number[]]
 
-function sumCombination(
+async function sumCombination(
 	target: number,
 	sum: number,
 	inputs: number[],
 	combo: number[],
+	cooperative: () => Promise<any>,
 	current = 0
-): number {
+): Promise<number> {
 	if (sum === target) {
 		return 1
 	}
@@ -47,7 +48,15 @@ function sumCombination(
 		const nextCombo = [...combo]
 		nextCombo[current] = i
 
-		found += sumCombination(target, nextSum, inputs, nextCombo, current + 1)
+		found += await sumCombination(
+			target,
+			nextSum,
+			inputs,
+			nextCombo,
+			cooperative,
+			current + 1
+		)
+		await cooperative()
 
 		i++
 		nextSum = sum + i * baseInput
@@ -55,9 +64,12 @@ function sumCombination(
 	return found
 }
 
-export function sumCombinations(data: SumInput) {
+export async function sumCombinations(
+	data: SumInput,
+	cooperative: () => Promise<any>
+) {
 	const [target, inputs] = data
 	inputs.sort()
 	const combo = new Array(inputs.length).fill(0)
-	return sumCombination(target, 0, inputs, combo)
+	return await sumCombination(target, 0, inputs, combo, cooperative)
 }

--- a/src/cct/valid-math-expressions.test.ts
+++ b/src/cct/valid-math-expressions.test.ts
@@ -8,8 +8,10 @@ describe('Find All Valid Math Expressions', function () {
 	this.timeout(5 /* s */ * 1000 /* ms */)
 
 	const solveExample =
-		(data: MathExpressionInput, expected: string[]) => () => {
-			const result = solveValidMathExpressions(data)
+		(data: MathExpressionInput, expected: string[]) => async () => {
+			const result = await solveValidMathExpressions(data, () =>
+				Promise.resolve()
+			)
 			expect(result).to.deep.equal(expected)
 		}
 

--- a/src/fuzz-contract.ts
+++ b/src/fuzz-contract.ts
@@ -3,6 +3,7 @@ import { NsLogger } from './logging/logger'
 
 export async function main(ns: NS) {
 	const quietLogger = new NsLogger(ns)
+	const cooperative = async () => await ns.sleep(20 /* ms */)
 	const logger = new NsLogger(ns, true)
 
 	const [contractType, contractCount] = ns.args
@@ -30,9 +31,10 @@ export async function main(ns: NS) {
 
 		const start = performance.now()
 
-		const { known, result } = evaluateCct(
+		const { known, result } = await evaluateCct(
 			contractType,
 			data,
+			cooperative,
 			quietLogger.getLogger(),
 			true
 		)


### PR DESCRIPTION
The game wants occaisional ns.sleep() calls to cooperate with its multithreading, so thread such calls through the slower recursive algorithms to avoid locking the game.