### PR TITLE
🐱‍💻 Double the Material Round 0 desired offer

### DIFF
--- a/src/services/corporation/material-round-0.ts
+++ b/src/services/corporation/material-round-0.ts
@@ -23,7 +23,7 @@ const DesiredMaterial: Partial<Record<BoostMaterial, number>> = {
 	[BoostMaterials.AiCores]: 75,
 	[BoostMaterials.RealEstate]: 27_000,
 }
-const DesiredOffer = 100_000_000_000
+const DesiredOffer = 200_000_000_000
 
 const SellAll = 'MAX'
 const SellAtMarketPrice = 'MP'


### PR DESCRIPTION
The round 1 purchases are based on the double offer amount so spend more time waiting for the right offer rather than waiting for the right revenue in round 1.