### PR TITLE
🐛 Fix valid math equation's leading zero test again

### DIFF
--- a/src/cct/valid-math-expressions.test.ts
+++ b/src/cct/valid-math-expressions.test.ts
@@ -54,6 +54,12 @@ describe('Find All Valid Math Expressions', function () {
 		solveExample(['480205', -97], [])
 	)
 
+	// slow test
+	it.skip(
+		'solves wild failure 98042474106',
+		solveExampleLength(['98042474106', 21], 1808)
+	)
+
 	it(
 		'solves wild example 6323557575',
 		solveExample(

--- a/src/cct/valid-math-expressions.ts
+++ b/src/cct/valid-math-expressions.ts
@@ -34,7 +34,7 @@ import { Logger } from 'tslog'
 
 export type MathExpressionInput = [string, number]
 
-const LeadingZeroRegex = /0\d/
+const LeadingZeroRegex = /^0\d/
 
 async function* generatePossibleSolutions(
 	input: number[],


### PR DESCRIPTION
Leading implies "starts with", but was missing the regex ^ anchor